### PR TITLE
Limited location autocomplete to (cities) and country level.

### DIFF
--- a/locompleter.js
+++ b/locompleter.js
@@ -31,7 +31,7 @@ angular.module('locompleter', [])
             /* Query options - limit to city and country */
             var options = {
                 types: ['(cities)', 'country']
-            }
+            };
             var autocomplete = new google.maps.places.Autocomplete($element[0], options);
 
             autocomplete.addListener('place_changed', function () {

--- a/locompleter.js
+++ b/locompleter.js
@@ -30,7 +30,7 @@ angular.module('locompleter', [])
           googleMaps.init(function onReady() {
             /* Query options - limit to city and country */
             var options = {
-                types: ['(cities)', 'country'];
+                types: ['(cities)', 'country']
             }
             var autocomplete = new google.maps.places.Autocomplete($element[0], options);
 

--- a/locompleter.js
+++ b/locompleter.js
@@ -28,7 +28,11 @@ angular.module('locompleter', [])
       controller: ['$element', '$scope', 'googleMaps',
         function ($element, $scope, googleMaps) {
           googleMaps.init(function onReady() {
-            var autocomplete = new google.maps.places.Autocomplete($element[0], {});
+            /* Query options - limit to city and country */
+            var options = {
+                types: ['(cities)', 'country'];
+            }
+            var autocomplete = new google.maps.places.Autocomplete($element[0], options);
 
             autocomplete.addListener('place_changed', function () {
               var placeData = autocomplete.getPlace();


### PR DESCRIPTION
Added an options object to contain query parameters for the Google location autocomplete. Added the 'types' parameter with '(cities)' and 'country' attributes to limit autocomplete results, as per the following discussion:
https://bugzilla.mozilla.org/show_bug.cgi?id=1052039 

The main goal is to protect privacy by preventing users from inputting their personal address details.
